### PR TITLE
Fix: Use TIMEZONE instead && Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ WORKDIR /home/botuser
 
 RUN poetry install --no-interaction --no-ansi --no-dev
 
-COPY discord_reminder_bot/main.py discord_reminder_bot/settings.py /home/botuser/discord_reminder_bot/
+COPY discord_reminder_bot/main.py discord_reminder_bot/settings.py discord_reminder_bot/countdown.py /home/botuser/discord_reminder_bot/
 
 VOLUME ["/home/botuser/data/"]
 

--- a/discord_reminder_bot/main.py
+++ b/discord_reminder_bot/main.py
@@ -146,7 +146,7 @@ async def command_modify(ctx: SlashContext, time_or_message: str):
                     f"{response_new_date.clean_content}",
                     settings={
                         "PREFER_DATES_FROM": "future",
-                        "TO_TIMEZONE": f"{config_timezone}",
+                        "TIMEZONE": f"{config_timezone}",
                     },
                 )
                 date_new = parsed_date.strftime("%Y-%m-%d %H:%M:%S")
@@ -446,7 +446,7 @@ async def remind_add(
         f"{message_date}",
         settings={
             "PREFER_DATES_FROM": "future",
-            "TO_TIMEZONE": f"{config_timezone}",
+            "TIMEZONE": f"{config_timezone}",
         },
     )
 


### PR DESCRIPTION
Hi, thanks for the bot.
I am using this cool bot and found that some codes need to be modified otherwise it doesn't work properly.

- /remind add: Won't parse as Timezone 
(I am using Asia/Tokyo, and it will parse time to UTC time)
<img width="444" alt="Screen Shot 2022-09-13 at 20 05 12" src="https://user-images.githubusercontent.com/35224826/189885741-a8939a48-788e-4386-9c44-6191178de95f.png">

- Missing python source in Dockerfile  COPY